### PR TITLE
Update newline_placeholder

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -7,7 +7,7 @@ from aqt import gui_hooks
 from aqt import mw
 
 Reviewer.typeboxAnsPat = r"\[\[typebox:(.*?)\]\]"
-Reviewer.newline_placeholder = "__typeboxnewline__"
+Reviewer.newline_placeholder = "_̲_̲t̲y̲p̲e̲b̲o̲x̲n̲e̲w̲l̲i̲n̲e̲__"
 
 def typeboxAnsFilter(self, buf: str) -> str:
 	# replace the typebox pattern for questions, and if question has typebox,


### PR DESCRIPTION
In some cases, `compare_answer` could confuse parts of your typed-in text, with sequences of characters found within the string "typeboxnewline", especially when your input text varies a lot from the expected answer, leading to the text "__typeboxnewline__" sometimes appearing in the UI, and your input answer has multiple newlines.

Updated the newline_placeholder variable to now consist entirely of unicode characters that look similar to the original value, but which are entirely unicode values and are very unlikely to match regular user input.